### PR TITLE
Remove stray prompt from guide

### DIFF
--- a/docs/security-monitoring-guide.md
+++ b/docs/security-monitoring-guide.md
@@ -206,4 +206,4 @@ For issues or questions:
 1. Check the troubleshooting section
 2. Review system logs
 3. Submit an issue in the project repository
-4. Contact the development team 
+4. Contact the development team


### PR DESCRIPTION
## Summary
- fix stray shell prompt in `security-monitoring-guide.md`

## Testing
- `npm test` *(fails: Error: no test specified)*