### PR TITLE
test: await async content safety checks

### DIFF
--- a/server/src/tests/contentSafety.test.ts
+++ b/server/src/tests/contentSafety.test.ts
@@ -12,7 +12,7 @@ describe('ContentSafetyService', () => {
   });
 
   describe('validateResponse', () => {
-    it('should allow medical and health-related content in Vietnamese', () => {
+    it('should allow medical and health-related content in Vietnamese', async () => {
       const healthQueries = [
         // Medical advice queries
         'Tôi bị đau đầu thường xuyên, có cách nào chữa theo YHCT không?',
@@ -37,9 +37,9 @@ describe('ContentSafetyService', () => {
         'Mua 1 tặng 1 cho tất cả các mặt hàng'
       ];
 
-      healthQueries.forEach(query => {
-        expect(() => safetyService.validateResponse(query, 'vi')).not.toThrow();
-      });
+      for (const query of healthQueries) {
+        await expect(safetyService.validateResponse(query, 'vi')).resolves.not.toThrow();
+      }
     });
 
     it('has basic content safety functionality', () => {

--- a/server/src/tests/sampleQuestions.test.ts
+++ b/server/src/tests/sampleQuestions.test.ts
@@ -3,18 +3,14 @@ import { contentSafetyService } from '../services/ContentSafety';
 import { ContentSafetyError } from '../utils/errors';
 
 describe('Sample Questions', () => {
-  it('should have valid questions that do not trigger content safety restrictions', () => {
-    sampleQuestions.forEach(({ question, title }) => {
-      expect(() => {
-        contentSafetyService.validateContent(question);
-        contentSafetyService.validateResponse(question, 'vi');
-      }).not.toThrow(ContentSafetyError);
+  it('should have valid questions that do not trigger content safety restrictions', async () => {
+    for (const { question, title } of sampleQuestions) {
+      await expect(contentSafetyService.validateContent(question)).resolves.not.toThrow();
+      await expect(contentSafetyService.validateResponse(question, 'vi')).resolves.not.toThrow();
 
-      expect(() => {
-        contentSafetyService.validateContent(title);
-        contentSafetyService.validateResponse(title, 'vi');
-      }).not.toThrow(ContentSafetyError);
-    });
+      await expect(contentSafetyService.validateContent(title)).resolves.not.toThrow();
+      await expect(contentSafetyService.validateResponse(title, 'vi')).resolves.not.toThrow();
+    }
   });
 
   it('should have non-empty titles and questions', () => {


### PR DESCRIPTION
## Summary
- await asynchronous validation methods in content safety tests

## Testing
- `npm test` *(fails: jest not found)*