### PR TITLE
fix: add missing GraphQL dependencies for Weaviate embedded

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -33,6 +33,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "graphql": "^16.8.1",
+    "graphql-request": "^6.1.0",
     "multer": "^2.0.2",
     "pinyin": "^4.0.0",
     "socket.io": "^4.8.1",


### PR DESCRIPTION
## Problem
The server was failing to start in Docker with the following error:
```
Failed to initialize Weaviate Embedded: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'graphql' imported from /app/node_modules/graphql-request/build/esm/resolveRequestDocument.js
```

## Solution
Added the missing GraphQL dependencies to `server/package.json`:
- `graphql: ^16.8.1` - Core GraphQL library required by weaviate-ts-embedded
- `graphql-request: ^6.1.0` - GraphQL HTTP client functionality

## Changes
- ✅ Added `graphql` dependency to server package.json
- ✅ Added `graphql-request` dependency to server package.json

## Testing
After this change, the Docker container should build and start successfully without the GraphQL module errors.

## Impact
- Fixes Weaviate Embedded initialization
- Resolves Context Engine startup failures
- Enables proper vector store functionality in production Docker environment

Closes the Docker startup issue with missing GraphQL dependencies.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author