### PR TITLE
Fix Unicode cache key encoding in ContextEngine

### DIFF
--- a/server/src/services/ContextEngine.ts
+++ b/server/src/services/ContextEngine.ts
@@ -372,7 +372,7 @@ export class ContextEngine {
   }
 
   private generateCacheKey(chatId: string, query?: string): string {
-    const queryHash = query ? btoa(query).slice(0, 8) : 'noquery';
+    const queryHash = query ? Buffer.from(query, 'utf8').toString('base64').slice(0, 8) : 'noquery';
     return `context_${chatId}_${queryHash}`;
   }
 


### PR DESCRIPTION
## Problem

The MCP client was throwing `DOMException [InvalidCharacterError]: Invalid character` errors when users sent queries containing Unicode characters, emojis, or other non-ASCII content. This was happening in the `ContextEngine.generateCacheKey()` method.

## Root Cause

The `btoa()` function only accepts ASCII characters. When a user query contained Unicode characters, `btoa(query)` would throw an "Invalid character" error.

## Solution

Replaced `btoa(query)` with `Buffer.from(query, 'utf8').toString('base64')` which:

- ✅ Properly handles Unicode characters and emojis
- ✅ Maintains the same base64 encoding functionality
- ✅ Preserves the existing cache key format
- ✅ Is fully backwards compatible

## Changes

- Modified `ContextEngine.generateCacheKey()` method in `server/src/services/ContextEngine.ts`
- Single line change: replaced `btoa(query)` with `Buffer.from(query, 'utf8').toString('base64')`

## Testing

- [x] Server builds successfully
- [x] No other instances of `btoa()` found in TypeScript codebase
- [x] Cache key format remains unchanged for backwards compatibility

## Impact

This fix resolves MCP client crashes when users send queries with Unicode content, improving the overall stability and user experience of the chat application.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author